### PR TITLE
Jackson databind CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 4.0-rc1 (May 31, 2021)
+## 4.0-rc1-1.0.1 (May 31, 2021)
+
+* Addressed jackson databind CVE's
+
+## 4.0-rc1-1.0.0 (May 31, 2021)
 
 * Upgrade to Apache Cassandra 4.0-rc1
 

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.instaclustr</groupId>
         <artifactId>cassandra-lucene-index-parent</artifactId>
-        <version>4.0-rc1-1.0.0</version>
+        <version>4.0-rc1-1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -39,12 +39,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.instaclustr</groupId>
         <artifactId>cassandra-lucene-index-parent</artifactId>
-        <version>4.0-rc1-1.0.0</version>
+        <version>4.0-rc1-1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -97,12 +97,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     
     <groupId>com.instaclustr</groupId>
     <artifactId>cassandra-lucene-index-parent</artifactId>
-    <version>4.0-rc1-1.0.0</version>
+    <version>4.0-rc1-1.0.1</version>
     <packaging>pom</packaging>
     
     <name>Cassandra Lucene index</name>
@@ -96,7 +96,8 @@
     <properties>
         <cassandra.version>4.0-rc1</cassandra.version>
         
-        <jackson.version>2.9.10</jackson.version>
+        <jackson.core.version>2.9.10</jackson.core.version>
+        <jackson.databind.version>2.9.10.8</jackson.databind.version>
         <jacoco-IT-argline></jacoco-IT-argline>
         <jts.version>1.14.0</jts.version>
         <lucene.version>5.5.4</lucene.version>

--- a/testsAT/pom.xml
+++ b/testsAT/pom.xml
@@ -26,12 +26,12 @@
     <parent>
         <groupId>com.instaclustr</groupId>
         <artifactId>cassandra-lucene-index-parent</artifactId>
-        <version>4.0-rc1-1.0.0</version>
+        <version>4.0-rc1-1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>cassandra-lucene-index-tests</artifactId>
-    <version>4.0-rc1-1.0.0</version>
+    <version>4.0-rc1-1.0.1</version>
     
     <packaging>jar</packaging>
     <name>Cassandra Lucene Index acceptance tests</name>

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/PluginTestFramework.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/PluginTestFramework.java
@@ -28,7 +28,7 @@ public abstract class PluginTestFramework {
 
     static class NestedSingleton implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
 
-        public static final String pluginCassandraVersion = System.getProperty("plugin.version", "4.0-rc1-1.0.0");
+        public static final String pluginCassandraVersion = System.getProperty("plugin.version", "4.0-rc1-1.0.1");
         public static final String cassandraVersion = System.getProperty("cassandra.version", "4.0-rc1");
 
         private static volatile boolean disconnected = false;


### PR DESCRIPTION
Address jackson databind CVE's:

- CVE-2019-16943
- CVE-2019-17531
- CVE-2019-20330
- CVE-2020-8840
- CVE-2020-9546
- CVE-2020-9547
- CVE-2020-9548

All are addressed in v2.9.10.4+
