### PR TITLE
4.1.6 issue - java.lang.NoClassDefFoundError: org.apache.cassandra.service.LuceneStorageProxy (initialization failure)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             - m2-{{ checksum "pom.xml" }}
             - m2-
 
-      - run: mvn clean install -DoutputDirectory=/tmp/artifacts -Pdeb,rpm -Dcassandra.version=4.1.3
+      - run: mvn clean install -DoutputDirectory=/tmp/artifacts -Pdeb,rpm -Dcassandra.version=4.1.6
 
       - save_cache:
           paths:

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,17 @@
+
+================================
+Project Status
+================================
+Important project update regarding Apache Cassandra 5.0
+
+We will not upgrade the Cassandra Lucene Index to support Apache Cassandra 5.0.
+
+This decision stems from the introduction of `Storage Attached Indexing (SAI) <https://cassandra.apache.org/doc/latest/cassandra/developing/cql/indexing/sai/sai-concepts.html>`__, which offers integrated, native indexing capabilities that are more aligned with Cassandra’s performance and scalability goals.
+
+We remain committed to supporting and maintaining the Cassandra Lucene Index for currently `supported <https://github.com/instaclustr/cassandra-lucene-index/releases>`__ and newer versions of Apache Cassandra 4 (including minor and patch-level versions).
+For more detailed information, please refer to our official `blog post <https://www.instaclustr.com/blog/cassandra-lucene-index-update/>`__.
+
+
 ================================
 Cassandra Lucene Index
 ================================

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.instaclustr</groupId>
         <artifactId>cassandra-lucene-index-parent</artifactId>
-        <version>4.1.5-1.0.0</version>
+        <version>4.1.6-1.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.instaclustr</groupId>
         <artifactId>cassandra-lucene-index-parent</artifactId>
-        <version>4.1.5-1.0.0</version>
+        <version>4.1.6-1.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
@@ -69,8 +69,8 @@ class IndexQueryHandler extends QueryHandler with Logging {
       state: QueryState,
       options: BatchQueryOptions,
       payload: Payload,
-      queryStartNanoTime: RequestTime): ResultMessage = {
-    QueryProcessor.instance.processBatch(statement, state, options, payload, queryStartNanoTime)
+      queryStartNanoTime: long): ResultMessage = {
+    QueryProcessor.instance.processBatch(statement, state, options, payload, RequestTime(queryStartNanoTime))
   }
 
   /** @inheritdoc */
@@ -79,17 +79,17 @@ class IndexQueryHandler extends QueryHandler with Logging {
       state: QueryState,
       options: QueryOptions,
       payload: Payload,
-      queryStartNanoTime: RequestTime): ResultMessage = {
+      queryStartNanoTime: long): ResultMessage = {
     QueryProcessor.metrics.preparedStatementsExecuted.inc()
-    processStatement(statement, state, options, queryStartNanoTime)
+    processStatement(statement, state, options, RequestTime(queryStartNanoTime))
   }
 
   override def process(statement: CQLStatement,
                        state: QueryState,
                        options: QueryOptions,
                        customPayload: java.util.Map[String, ByteBuffer],
-                       queryStartNanoTime: RequestTime): ResultMessage = {
-    processStatement(statement, state, options, queryStartNanoTime)
+                       queryStartNanoTime: long): ResultMessage = {
+    processStatement(statement, state, options, RequestTime(queryStartNanoTime))
   }
 
   def processStatement(

--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
@@ -35,7 +35,6 @@ import org.apache.cassandra.service.{ClientState, LuceneStorageProxy, QueryState
 import org.apache.cassandra.transport.messages.ResultMessage
 import org.apache.cassandra.transport.messages.ResultMessage.Rows
 import org.apache.cassandra.utils.{FBUtilities, MD5Digest}
-import org.apache.cassandra.transport.Dispatcher.RequestTime
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
@@ -70,7 +69,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
       options: BatchQueryOptions,
       payload: Payload,
       queryStartNanoTime: Long): ResultMessage = {
-    QueryProcessor.instance.processBatch(statement, state, options, payload, RequestTime(queryStartNanoTime))
+    QueryProcessor.instance.processBatch(statement, state, options, payload, queryStartNanoTime)
   }
 
   /** @inheritdoc */
@@ -81,7 +80,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
       payload: Payload,
       queryStartNanoTime: Long): ResultMessage = {
     QueryProcessor.metrics.preparedStatementsExecuted.inc()
-    processStatement(statement, state, options, RequestTime(queryStartNanoTime))
+    processStatement(statement, state, options, queryStartNanoTime)
   }
 
   override def process(statement: CQLStatement,
@@ -89,7 +88,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
                        options: QueryOptions,
                        customPayload: java.util.Map[String, ByteBuffer],
                        queryStartNanoTime: Long): ResultMessage = {
-    processStatement(statement, state, options, RequestTime(queryStartNanoTime))
+    processStatement(statement, state, options, queryStartNanoTime)
   }
 
   def processStatement(

--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
@@ -69,7 +69,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
       state: QueryState,
       options: BatchQueryOptions,
       payload: Payload,
-      queryStartNanoTime: long): ResultMessage = {
+      queryStartNanoTime: Long): ResultMessage = {
     QueryProcessor.instance.processBatch(statement, state, options, payload, RequestTime(queryStartNanoTime))
   }
 
@@ -79,7 +79,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
       state: QueryState,
       options: QueryOptions,
       payload: Payload,
-      queryStartNanoTime: long): ResultMessage = {
+      queryStartNanoTime: Long): ResultMessage = {
     QueryProcessor.metrics.preparedStatementsExecuted.inc()
     processStatement(statement, state, options, RequestTime(queryStartNanoTime))
   }
@@ -88,7 +88,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
                        state: QueryState,
                        options: QueryOptions,
                        customPayload: java.util.Map[String, ByteBuffer],
-                       queryStartNanoTime: long): ResultMessage = {
+                       queryStartNanoTime: Long): ResultMessage = {
     processStatement(statement, state, options, RequestTime(queryStartNanoTime))
   }
 

--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
@@ -35,6 +35,7 @@ import org.apache.cassandra.service.{ClientState, LuceneStorageProxy, QueryState
 import org.apache.cassandra.transport.messages.ResultMessage
 import org.apache.cassandra.transport.messages.ResultMessage.Rows
 import org.apache.cassandra.utils.{FBUtilities, MD5Digest}
+import org.apache.cassandra.transport.Dispatcher.RequestTime
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
@@ -68,7 +69,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
       state: QueryState,
       options: BatchQueryOptions,
       payload: Payload,
-      queryStartNanoTime: Long): ResultMessage = {
+      queryStartNanoTime: RequestTime): ResultMessage = {
     QueryProcessor.instance.processBatch(statement, state, options, payload, queryStartNanoTime)
   }
 
@@ -78,7 +79,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
       state: QueryState,
       options: QueryOptions,
       payload: Payload,
-      queryStartNanoTime: Long): ResultMessage = {
+      queryStartNanoTime: RequestTime): ResultMessage = {
     QueryProcessor.metrics.preparedStatementsExecuted.inc()
     processStatement(statement, state, options, queryStartNanoTime)
   }
@@ -87,7 +88,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
                        state: QueryState,
                        options: QueryOptions,
                        customPayload: java.util.Map[String, ByteBuffer],
-                       queryStartNanoTime: Long): ResultMessage = {
+                       queryStartNanoTime: RequestTime): ResultMessage = {
     processStatement(statement, state, options, queryStartNanoTime)
   }
 

--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
@@ -68,8 +68,8 @@ class IndexQueryHandler extends QueryHandler with Logging {
       state: QueryState,
       options: BatchQueryOptions,
       payload: Payload,
-      queryStartNanoTime: Long): ResultMessage = {
-    QueryProcessor.instance.processBatch(statement, state, options, payload, queryStartNanoTime)
+      requestTime: Dispatcher.RequestTime) : ResultMessage = {
+    QueryProcessor.instance.processBatch(statement, state, options, payload, requestTime)
   }
 
   /** @inheritdoc */
@@ -78,24 +78,24 @@ class IndexQueryHandler extends QueryHandler with Logging {
       state: QueryState,
       options: QueryOptions,
       payload: Payload,
-      queryStartNanoTime: Long): ResultMessage = {
+      requestTime: Dispatcher.RequestTime): ResultMessage = {
     QueryProcessor.metrics.preparedStatementsExecuted.inc()
-    processStatement(statement, state, options, queryStartNanoTime)
+    processStatement(statement, state, options, requestTime)
   }
 
   override def process(statement: CQLStatement,
                        state: QueryState,
                        options: QueryOptions,
                        customPayload: java.util.Map[String, ByteBuffer],
-                       queryStartNanoTime: Long): ResultMessage = {
-    processStatement(statement, state, options, queryStartNanoTime)
+                       requestTime: Dispatcher.RequestTime): ResultMessage = {
+    processStatement(statement, state, options, requestTime)
   }
 
   def processStatement(
       statement: CQLStatement,
       state: QueryState,
       options: QueryOptions,
-      queryStartNanoTime: Long): ResultMessage = {
+      requestTime: Dispatcher.RequestTime): ResultMessage = {
 
     // Intercept Lucene index searches
     statement match {
@@ -104,7 +104,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
         if (expressions.nonEmpty) {
           val time = TimeCounter.start
           try {
-            return executeLuceneQuery(select, state, options, expressions, queryStartNanoTime)
+            return executeLuceneQuery(select, state, options, expressions, requestTime)
           } catch {
             case e: ReflectiveOperationException => throw new IndexException(e)
           } finally {
@@ -113,7 +113,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
         }
       case _ =>
     }
-    execute(statement, state, options, queryStartNanoTime)
+    execute(statement, state, options, requestTime)
   }
 
   def luceneExpressions(
@@ -146,8 +146,8 @@ class IndexQueryHandler extends QueryHandler with Logging {
   def execute(statement: CQLStatement,
               state: QueryState,
               options: QueryOptions,
-              queryStartNanoTime: Long): ResultMessage = {
-    val result = statement.execute(state, options, queryStartNanoTime)
+              requestTime: Dispatcher.RequestTime): ResultMessage = {
+    val result = statement.execute(state, options, requestTime)
     if (result == null) new ResultMessage.Void else result
   }
 
@@ -156,7 +156,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
       state: QueryState,
       options: QueryOptions,
       expressions: Map[Expression, Index],
-      queryStartNanoTime: Long): ResultMessage = {
+      requestTime: Dispatcher.RequestTime): ResultMessage = {
 
     if (expressions.size > 1) {
       throw new InvalidRequestException(
@@ -181,9 +181,9 @@ class IndexQueryHandler extends QueryHandler with Logging {
 
     // Take control of paging if there is paging and the query requires post processing
     if (search.requiresPostProcessing && page > 0 && page < limit) {
-      executeSortedLuceneQuery(select, state, options, partitioner, queryStartNanoTime)
+      executeSortedLuceneQuery(select, state, options, partitioner, requestTime)
     } else {
-      execute(select, state, options, queryStartNanoTime)
+      execute(select, state, options, requestTime)
     }
   }
 
@@ -192,7 +192,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
       state: QueryState,
       options: QueryOptions,
       partitioner: Partitioner,
-      queryStartNanoTime: Long): Rows = {
+      requestTime: Dispatcher.RequestTime): Rows = {
 
     // Check consistency level
     val consistency = options.getConsistency
@@ -215,8 +215,8 @@ class IndexQueryHandler extends QueryHandler with Logging {
     // Read data
     val data = query match {
       case group: Group if group.queries.size > 1 =>
-        LuceneStorageProxy.read(group, consistency, queryStartNanoTime)
-      case _ => query.execute(consistency, state.getClientState, queryStartNanoTime)
+        LuceneStorageProxy.read(group, consistency, requestTime)
+      case _ => query.execute(consistency, state.getClientState, requestTime)
     }
 
     val selectors = select.getSelection.newSelectors(options)

--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
@@ -35,6 +35,7 @@ import org.apache.cassandra.service.{ClientState, LuceneStorageProxy, QueryState
 import org.apache.cassandra.transport.messages.ResultMessage
 import org.apache.cassandra.transport.messages.ResultMessage.Rows
 import org.apache.cassandra.utils.{FBUtilities, MD5Digest}
+import org.apache.cassandra.transport.Dispatcher
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable

--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
@@ -216,7 +216,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
     // Read data
     val data = query match {
       case group: Group if group.queries.size > 1 =>
-        LuceneStorageProxy.read(group, consistency, requestTime.startedAtNanos())
+        LuceneStorageProxy.read(group, consistency, requestTime)
       case _ => query.execute(consistency, state.getClientState, requestTime)
     }
 

--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexQueryHandler.scala
@@ -216,7 +216,7 @@ class IndexQueryHandler extends QueryHandler with Logging {
     // Read data
     val data = query match {
       case group: Group if group.queries.size > 1 =>
-        LuceneStorageProxy.read(group, consistency, requestTime)
+        LuceneStorageProxy.read(group, consistency, requestTime.startedAtNanos())
       case _ => query.execute(consistency, state.getClientState, requestTime)
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     
     <groupId>com.instaclustr</groupId>
     <artifactId>cassandra-lucene-index-parent</artifactId>
-    <version>4.1.5-1.0.0</version>
+    <version>4.1.6-1.0.0</version>
     <packaging>pom</packaging>
     
     <name>Cassandra Lucene index</name>
@@ -94,7 +94,7 @@
     </distributionManagement>
     
     <properties>
-        <cassandra.version>4.1.5</cassandra.version>
+        <cassandra.version>4.1.6</cassandra.version>
         
         <jackson.core.version>2.13.2</jackson.core.version>
         <jackson.databind.version>2.13.2.2</jackson.databind.version>

--- a/testsAT/pom.xml
+++ b/testsAT/pom.xml
@@ -26,12 +26,12 @@
     <parent>
         <groupId>com.instaclustr</groupId>
         <artifactId>cassandra-lucene-index-parent</artifactId>
-        <version>4.1.5-1.0.0</version>
+        <version>4.1.6-1.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>cassandra-lucene-index-tests</artifactId>
-    <version>4.1.5-1.0.0</version>
+    <version>4.1.6-1.0.0</version>
     
     <packaging>jar</packaging>
     <name>Cassandra Lucene Index acceptance tests</name>

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/PluginTestFramework.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/PluginTestFramework.java
@@ -26,8 +26,8 @@ public abstract class PluginTestFramework {
 
     static class NestedSingleton implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
 
-        public static final String pluginCassandraVersion = System.getProperty("plugin.version", "4.1.5-1.0.0");
-        public static final String cassandraVersion = System.getProperty("cassandra.version", "4.1.5");
+        public static final String pluginCassandraVersion = System.getProperty("plugin.version", "4.1.6-1.0.0");
+        public static final String cassandraVersion = System.getProperty("cassandra.version", "4.1.6");
 
         private static volatile boolean disconnected = false;
         private static volatile boolean initialized = false;


### PR DESCRIPTION
- after https://github.com/apache/cassandra/commit/dc17c29724d86547538cc8116ff1a90d36a0bf3a,

  4.1.6 branch is broken. fix LuceneStorageProxy.java

```
Unexpected exception during request; channel = [id: 0xf3b04ed5, L:/172.19.138.44:9042 - R:/172.19.133.25:51606] 
java.lang.NoClassDefFoundError: org.apache.cassandra.service.LuceneStorageProxy (initialization failure)
    at java.base/java.lang.J9VMInternals.initializationAlreadyFailed(J9VMInternals.java:166)
    at com.stratio.cassandra.lucene.IndexPagingState.update(IndexPagingState.scala:152)
    ...
    at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:142)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
    at java.base/java.lang.Thread.run(Thread.java:839)
Caused by: java.lang.RuntimeException: java.lang.NoSuchMethodException: 
org.apache.cassandra.service.StorageProxy.fetchRows(java.util.List, org.apache.cassandra.db.ConsistencyLevel, long)
    at org.apache.cassandra.service.LuceneStorageProxy.<clinit>(LuceneStorageProxy.java:59)
    ... 22 common frames omitted
Caused by: java.lang.NoSuchMethodException: 
org.apache.cassandra.service.StorageProxy.fetchRows(java.util.List, org.apache.cassandra.db.ConsistencyLevel, long)
    at java.base/java.lang.Class.newNoSuchMethodException(Class.java:649)
    at java.base/java.lang.Class.throwExceptionOrReturnNull(Class.java:1449)
    ...
```