### PR TITLE
Issue 40 ORDER BY does not work fix

### DIFF
--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexReaderWide.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexReaderWide.scala
@@ -78,7 +78,7 @@ class IndexReaderWide(
 
     if (clusterings.isEmpty) return prepareNext()
 
-    val filter = new ClusteringIndexNamesFilter(clusterings, false)
+    val filter = new ClusteringIndexNamesFilter(clusterings, command.isReversed)
     nextData = Some(read(key, filter))
 
     nextData.foreach(

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/issues/OrderByClauseTest.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/issues/OrderByClauseTest.java
@@ -1,0 +1,100 @@
+package com.stratio.cassandra.lucene.issues;
+
+import com.datastax.driver.core.Row;
+import com.stratio.cassandra.lucene.BaseTest;
+import com.stratio.cassandra.lucene.util.CassandraUtils;
+import com.stratio.cassandra.lucene.util.CassandraUtilsSelect;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.stratio.cassandra.lucene.builder.Builder.*;
+
+public class OrderByClauseTest extends BaseTest {
+
+    @Test
+    public void test() {
+        HashMap<String, String> row1 = new LinkedHashMap<>();
+        row1.put("id", "1");
+        row1.put("sent_at", "'2025-01-07 15:10:50.506000+0000'");
+        row1.put("tags", "'test'");
+
+        HashMap<String, String> row2 = new LinkedHashMap<>();
+        row2.put("id", "1");
+        row2.put("sent_at", "'2025-01-07 15:10:50.507000+0000'");
+        row2.put("tags", "'test'");
+
+        HashMap<String, String> row3 = new LinkedHashMap<>();
+        row3.put("id", "1");
+        row3.put("sent_at", "'2025-01-07 15:10:51.665000+0000'");
+        row3.put("tags", "'test'");
+
+        HashMap<String, String> row4 = new LinkedHashMap<>();
+        row4.put("id", "1");
+        row4.put("sent_at", "'2025-01-07 15:10:51.666000+0000'");
+        row4.put("tags", "'test'");
+
+        HashMap<String, String> row5 = new LinkedHashMap<>();
+        row5.put("id", "1");
+        row5.put("sent_at", "'2025-01-07 15:11:34.390000+0000'");
+        row5.put("tags", "'test'");
+
+        HashMap<String, String> row6 = new LinkedHashMap<>();
+        row6.put("id", "1");
+        row6.put("sent_at", "'2025-01-08 15:11:34.390000+0000'");
+        row6.put("tags", "'test'");
+
+        List<HashMap<String, String>> expectedResultOrder = new ArrayList<>();
+        expectedResultOrder.add(row6);
+        expectedResultOrder.add(row5);
+        expectedResultOrder.add(row4);
+        expectedResultOrder.add(row3);
+        expectedResultOrder.add(row2);
+        expectedResultOrder.add(row1);
+
+//        CassandraUtils.builder("issue_18")
+//                .withPartitionKey("idcol")
+//                .withColumn("idcol", "int")
+//                .withColumn("testtextcol", "text", stringMapper())
+//                .withColumn("testmapcol", "map<text,text>", stringMapper())
+//                .build()
+//                .createKeyspace()
+//                .createTable()
+//                .createIndex()
+//                .insert(data1, data2, data3, data4)
+//                .refresh()
+//                .filter(match("testmapcol$attb1", "row1attb1Val"))
+//                .checkUnorderedColumns("idcol", 1)
+//                .dropTable()
+//                .dropKeyspace();
+        CassandraUtils.builder("order_by_test").withTable("order_by_test_table")
+                .withIndexName("order_by_test_table_index")
+                .withColumn("id", "int", integerMapper())
+                .withColumn("sent_at", "timestamp", longMapper())
+                .withColumn("tags", "text", stringMapper())
+                .withPartitionKey("id")
+                .withClusteringKey("sent_at")
+                .build()
+                .createKeyspace()
+                .createTable()
+                .createIndex()
+                .insert(row1, row2, row3, row4, row5, row6)
+                .select()
+                .andEq("id", 1)
+                .filter(wildcard("tags", "*"))
+                .andGte("sent_at", 1736262639000L)
+                .orderBy("sent_at", CassandraUtilsSelect.Order.DESC)
+                .checkOrderedColumns("sent_at", expectedResultOrder
+                        .stream()
+                        .map((row) -> row.get("sent_at"))
+                        .toArray()
+                )
+                .dropKeyspace();
+    }
+
+}

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/issues/OrderByClauseTest.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/issues/OrderByClauseTest.java
@@ -1,21 +1,12 @@
 package com.stratio.cassandra.lucene.issues;
 
-import com.datastax.driver.core.Row;
-import com.datastax.driver.core.TypeCodec;
 import com.stratio.cassandra.lucene.BaseTest;
 import com.stratio.cassandra.lucene.util.CassandraUtils;
 import com.stratio.cassandra.lucene.util.CassandraUtilsSelect;
 import org.junit.jupiter.api.Test;
-
-import java.text.DateFormat;
-import java.text.ParseException;
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.stratio.cassandra.lucene.builder.Builder.*;
 
@@ -63,21 +54,6 @@ public class OrderByClauseTest extends BaseTest {
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSX");
 
-//        CassandraUtils.builder("issue_18")
-//                .withPartitionKey("idcol")
-//                .withColumn("idcol", "int")
-//                .withColumn("testtextcol", "text", stringMapper())
-//                .withColumn("testmapcol", "map<text,text>", stringMapper())
-//                .build()
-//                .createKeyspace()
-//                .createTable()
-//                .createIndex()
-//                .insert(data1, data2, data3, data4)
-//                .refresh()
-//                .filter(match("testmapcol$attb1", "row1attb1Val"))
-//                .checkUnorderedColumns("idcol", 1)
-//                .dropTable()
-//                .dropKeyspace();
         CassandraUtils.builder("order_by_test").withTable("order_by_test_table")
                 .withIndexName("order_by_test_table_index")
                 .withColumn("id", "int", integerMapper())
@@ -107,5 +83,4 @@ public class OrderByClauseTest extends BaseTest {
                 )
                 .dropKeyspace();
     }
-
 }

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/issues/OrderByClauseTest.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/issues/OrderByClauseTest.java
@@ -1,15 +1,19 @@
 package com.stratio.cassandra.lucene.issues;
 
 import com.datastax.driver.core.Row;
+import com.datastax.driver.core.TypeCodec;
 import com.stratio.cassandra.lucene.BaseTest;
 import com.stratio.cassandra.lucene.util.CassandraUtils;
 import com.stratio.cassandra.lucene.util.CassandraUtilsSelect;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -57,6 +61,8 @@ public class OrderByClauseTest extends BaseTest {
         expectedResultOrder.add(row2);
         expectedResultOrder.add(row1);
 
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSX");
+
 //        CassandraUtils.builder("issue_18")
 //                .withPartitionKey("idcol")
 //                .withColumn("idcol", "int")
@@ -84,6 +90,7 @@ public class OrderByClauseTest extends BaseTest {
                 .createTable()
                 .createIndex()
                 .insert(row1, row2, row3, row4, row5, row6)
+                .refresh()
                 .select()
                 .andEq("id", 1)
                 .filter(wildcard("tags", "*"))
@@ -91,7 +98,11 @@ public class OrderByClauseTest extends BaseTest {
                 .orderBy("sent_at", CassandraUtilsSelect.Order.DESC)
                 .checkOrderedColumns("sent_at", expectedResultOrder
                         .stream()
-                        .map((row) -> row.get("sent_at"))
+                        .map((row) -> {
+                                String sentAt = row.get("sent_at");
+                                sentAt = sentAt.replace("'", "");
+                                return Date.from(Instant.from(formatter.parse(sentAt)));
+                        })
                         .toArray()
                 )
                 .dropKeyspace();

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/util/CassandraUtilsSelect.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/util/CassandraUtilsSelect.java
@@ -48,6 +48,9 @@ public class CassandraUtilsSelect {
     private boolean allowFiltering = false;
     private ConsistencyLevel consistency;
     private boolean useNewQuerySyntax;
+    private String orderByColumn;
+    private boolean useOrderBy = false;
+    private Order orderByOrder;
 
     public CassandraUtilsSelect(CassandraUtils parent) {
         this.parent = parent;
@@ -143,6 +146,18 @@ public class CassandraUtilsSelect {
         return this;
     }
 
+    /**
+     * Appends ORDER BY clause to the select query.
+     * @param column is a column name by which the result should be ordered.
+     * @param orderBy is result order.
+     */
+    public CassandraUtilsSelect orderBy(String column, Order orderBy) {
+        this.useOrderBy = true;
+        this.orderByColumn = column;
+        this.orderByOrder = orderBy;
+        return this;
+    }
+
     public CassandraUtilsSelect consistency(ConsistencyLevel consistency) {
         this.consistency = consistency;
         return this;
@@ -168,6 +183,12 @@ public class CassandraUtilsSelect {
             sb.append(" ");
             sb.append(extra);
             sb.append(" ");
+        }
+        if (useOrderBy) {
+            sb.append(" ORDER BY ");
+            sb.append(orderByColumn);
+            sb.append(" ");
+            sb.append(orderByOrder.toString());
         }
         sb.append(" LIMIT ").append(limit == null ? CassandraConfig.LIMIT : limit);
         if (allowFiltering) {
@@ -238,5 +259,22 @@ public class CassandraUtilsSelect {
 
     public <T extends Exception> CassandraUtils check(Class<T> expectedClass, CassandraUtils.ExceptionMessage expectedMessage) {
         return parent.check(this::get, expectedClass, expectedMessage);
+    }
+
+    /**
+     * Defines possible select order for ORDER BY clause.
+     */
+    public enum Order {
+        ASC, DESC;
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case ASC: return "ASC";
+                case DESC: return "DESC";
+            }
+            // Should be unreachable
+            return "";
+        }
     }
 }


### PR DESCRIPTION
This PR provides a fix for issue #40 related to not working the `ORDER BY` clause when the Lucene expression is presented in the query.

This patch will not impact codebases which don't use Lucene expressions with `ORDER BY DESC` clouse before. `ReadCommand.isReserved()` returns `true` only when cql **SELECT** query contains  `ORDER BY DESC` clause.

Details are described under the issue.

closes #40