### PR TITLE
Close and skip empty partition in IndexReaderSkinny

### DIFF
--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexReaderSkinny.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexReaderSkinny.scala
@@ -41,8 +41,18 @@ class IndexReaderSkinny(
       val nextDoc = documents.next
       val key = service.decoratedKey(nextDoc._1)
       val filter = command.clusteringIndexFilter(key)
-      nextData = Some(read(key, filter))
-      nextData.foreach(d => if (d.isEmpty) d.close())
+      val data = read(key, filter)
+      // If the Lucene hit maps to a row that no longer exists in the base table (an orphaned
+      // index document, e.g. after a delete whose SSTables have been compacted away), the read
+      // returns an empty partition. It must be closed and SKIPPED, not returned: handing an empty
+      // partition to the read pipeline makes Cassandra's CheckForAbort transformation attach to a
+      // second BaseRows, which throws IllegalArgumentException and surfaces as ReadFailure(1300).
+      // IndexReaderWide already skips empty partitions; this keeps the skinny reader consistent.
+      if (data.isEmpty) {
+        data.close()
+      } else {
+        nextData = Some(data)
+      }
     }
     nextData.isDefined
   }

--- a/plugin/src/test/scala/com/stratio/cassandra/lucene/IndexReaderSkinnyTest.scala
+++ b/plugin/src/test/scala/com/stratio/cassandra/lucene/IndexReaderSkinnyTest.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2014 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.cassandra.lucene
+
+import com.stratio.cassandra.lucene.index.DocumentIterator
+import org.apache.cassandra.db.filter.ClusteringIndexFilter
+import org.apache.cassandra.db.rows.UnfilteredRowIterator
+import org.apache.cassandra.db.{DecoratedKey, ReadCommand}
+import org.apache.lucene.document.Document
+import org.apache.lucene.search.ScoreDoc
+import org.junit.runner.RunWith
+import org.mockito.Mockito._
+import org.scalatestplus.junit.JUnitRunner
+
+import scala.collection.mutable
+
+/** Regression test for the fix in [[IndexReaderSkinny]]: a Lucene hit whose row no longer exists
+  * (an orphaned index document left after a delete whose SSTables were compacted away) yields an
+  * EMPTY partition on re-read. Such empty partitions must be closed and skipped, never returned to
+  * Cassandra's read pipeline -- returning them makes `ReadCommand.CheckForAbort` attach to a second
+  * `BaseRows` and the replica read fails with `ReadFailure(code=1300)`.
+  *
+  * The buggy version closed the empty partition but still left it in `nextData` (returning it);
+  * these tests fail against that version and pass against the fix.
+  */
+@RunWith(classOf[JUnitRunner])
+class IndexReaderSkinnyTest extends BaseScalaTest {
+
+  /** Test double that bypasses the storage engine: `read` just returns pre-canned partitions. */
+  private class TestReader(
+      service: IndexServiceSkinny,
+      command: ReadCommand,
+      documents: DocumentIterator,
+      results: mutable.Queue[UnfilteredRowIterator])
+    extends IndexReaderSkinny(service, command, null, null, documents) {
+    override protected def read(key: DecoratedKey, filter: ClusteringIndexFilter): UnfilteredRowIterator =
+      results.dequeue()
+  }
+
+  private def partition(empty: Boolean): UnfilteredRowIterator = {
+    val it = mock(classOf[UnfilteredRowIterator])
+    when(it.isEmpty).thenReturn(empty)
+    it
+  }
+
+  private def hit: (Document, ScoreDoc) = (new Document, new ScoreDoc(0, 1.0f))
+
+  test("prepareNext skips and closes empty (orphaned) partitions and returns the live one") {
+    val documents = mock(classOf[DocumentIterator])
+    when(documents.hasNext).thenReturn(true, true, true, false)
+    when(documents.next).thenReturn(hit, hit, hit)
+
+    val empty1 = partition(empty = true)
+    val empty2 = partition(empty = true)
+    val live = partition(empty = false)
+
+    val reader = new TestReader(
+      mock(classOf[IndexServiceSkinny]),
+      mock(classOf[ReadCommand]),
+      documents,
+      mutable.Queue(empty1, empty2, live))
+
+    reader.hasNext shouldBe true         // there IS a live result to return
+    reader.next shouldBe live            // and it is the live partition, not an empty one
+    verify(empty1).close()               // both orphaned partitions were closed ...
+    verify(empty2).close()
+    verify(live, never()).close()        // ... and the live one was not closed while preparing
+  }
+
+  test("prepareNext returns false when every hit is an empty (orphaned) partition") {
+    val documents = mock(classOf[DocumentIterator])
+    when(documents.hasNext).thenReturn(true, false)
+    when(documents.next).thenReturn(hit)
+
+    val empty = partition(empty = true)
+
+    val reader = new TestReader(
+      mock(classOf[IndexServiceSkinny]),
+      mock(classOf[ReadCommand]),
+      documents,
+      mutable.Queue(empty))
+
+    reader.hasNext shouldBe false        // nothing to return
+    verify(empty).close()                // the orphaned partition was closed
+  }
+}


### PR DESCRIPTION
## Fix `ReadFailure code=1300` on Lucene queries after DELETE + compaction

### Summary

`IndexReaderSkinny` can return an empty partition to Cassandra's read pipeline when a Lucene hit points to a row that no longer exists. This trips a `CheckForAbort` invariant on the replica and surfaces to clients as `ReadFailure(1300)`. This PR skips those empty partitions in `IndexReaderSkinny`, matching the behavior `IndexReaderWide` already has.

### The problem

After DELETE operations followed by compaction, Lucene `expr()` queries intermittently fail with:

```
ReadFailure: code=1300 [Replica(s) failed to execute read]
"received 0 responses and 1 failures ..."
```

The coordinator only reports an opaque `UNKNOWN` failure. The real cause is visible in the replica node's `system.log`:

```
java.lang.IllegalArgumentException: Attempted to attach 2nd different BaseRows in
StoppingTransformation; this is a bug.
    at org.apache.cassandra.db.ReadCommand$CheckForAbort.attachTo(ReadCommand.java:632)
    ...
    at org.apache.cassandra.db.partitions.UnfilteredPartitionIterators$Serializer.serialize(...)
```

### Root cause

A Lucene hit is only a pointer to a primary key. When the underlying row no longer exists — an orphaned index document left behind after a delete whose SSTables were later compacted away — re-reading it returns an empty partition.

`IndexReaderSkinny.prepareNext` closed that empty partition but still returned it downstream. `CheckForAbort` can only attach to one row iterator at a time, so the next non-empty partition trips its invariant and the replica read dies, producing `ReadFailure(1300)`.

`IndexReaderWide` already skips empty partitions; `IndexReaderSkinny` did not. This PR brings the two into alignment.

### The fix

Single-file change in `plugin/src/main/scala/com/stratio/cassandra/lucene/IndexReaderSkinny.scala`, method `prepareNext` — skip empty partitions instead of returning them:

```diff
-      nextData = Some(read(key, filter))
-      nextData.foreach(d => if (d.isEmpty) d.close())
+      val data = read(key, filter)
+      // Orphaned index doc (row deleted + SSTables compacted away) -> empty partition.
+      // Close and SKIP it; returning it makes CheckForAbort attach to a 2nd BaseRows -> ReadFailure(1300).
+      if (data.isEmpty) data.close()
+      else nextData = Some(data)
```

### Affected version

Reproduced against tag `cassandra-4.1.10-1.0.1`.

### How it was verified

Reproduced on a 3-node cluster with a CRUD-fuzz harness that interleaves inserts, deletes, flushes/compaction, and Lucene `expr()` queries:

- **Before the fix:** the harness consistently hits `ReadFailure(1300)` (around operation ~100), and the replica `system.log` shows the `Attempted to attach 2nd different BaseRows` `IllegalArgumentException`.
- **After the fix:** the same harness runs to completion (`ITERATIONS=10000`, `FLUSH_EVERY=25`) with no `ReadFailure` and no `BaseRows` exception in the logs.